### PR TITLE
Fix baselength bug and wrap forward function

### DIFF
--- a/pyramid.lua
+++ b/pyramid.lua
@@ -1,6 +1,15 @@
 --copyright Vishwesh Anand MMXV
 --builds a pyramid out of either stair blocks or regular blocks
 
+turtle.select(1)
+
+function tryForward()
+  while not turtle.forward() do
+    turtle.dig()
+    sleep(0.5)
+  end
+end
+
 io.write("Please enter desired pyramid length: ")
 baselength = tonumber(io.read()) --odd numbers are preferable
 while baselength>4 do --turtle doesn't build top of pyramid yet
@@ -8,14 +17,14 @@ while baselength>4 do --turtle doesn't build top of pyramid yet
     for x=1, baselength, 1 do
       turtle.placeDown()
       turtle.turnLeft()
-      turtle.forward()
+      tryForward()
       turtle.turnRight()
     end
     turtle.up()
     turtle.turnLeft()
-    turtle.forward()
+    tryForward()
     turtle.turnRight()
-    turtle.forward()
-    baselength = baselength - 1
+    tryForward()
+    baselength = baselength - 2
   end
 end


### PR DESCRIPTION
Create a wrapper function to ensure that turtle.forward() isn't skipped, and make sure each base is 2 less than previous instead of 1.